### PR TITLE
Add Config for Side Nav Title

### DIFF
--- a/config/theme.ini
+++ b/config/theme.ini
@@ -45,7 +45,7 @@ elements.footer.attributes.value = "Powered by Omeka S"
 elements.side_nav_title.name = "side_nav_title"
 elements.side_nav_title.attributes.id = "side_nav_title"
 elements.side_nav_title.type = "Omeka\Form\Element\HtmlTextarea"
-elements.side_nav_title.options.label = "Side Nav Title"
+elements.side_nav_title.options.label = "Side Navigation Title"
 elements.side_nav_title.options.info = "Title for Side Navigation"
 elements.side_nav_title.attributes.value = "Contents"
 

--- a/config/theme.ini
+++ b/config/theme.ini
@@ -42,6 +42,13 @@ elements.footer.options.label = "Footer Content"
 elements.footer.options.info = "HTML content to appear in the footer"
 elements.footer.attributes.value = "Powered by Omeka S"
 
+elements.side_nav_title.name = "side_nav_title"
+elements.side_nav_title.attributes.id = "side_nav_title"
+elements.side_nav_title.type = "Omeka\Form\Element\HtmlTextarea"
+elements.side_nav_title.options.label = "Side Nav Title"
+elements.side_nav_title.options.info = "Title for Side Navigation"
+elements.side_nav_title.attributes.value = "Contents"
+
 elements.side_nav.name = "side_nav"
 elements.side_nav.attributes.id = "side_nav"
 elements.side_nav.type = "Zend\Form\Element\Checkbox"

--- a/view/omeka/site/page/show.phtml
+++ b/view/omeka/site/page/show.phtml
@@ -38,7 +38,9 @@ $child_pages = $activeRoot['pages'];
 <?php if (!$this->themeSetting('side_nav') && $activePage && count($child_pages) != 0): ?>
         <div class="col-md-3">
             <div class="table-of-contents-nav">
-                <h3>Exhibit Contents</h3>
+                <?php if ($this->themeSetting('side_nav_title')): ?>
+                    <h3><?php echo $this->themeSetting('side_nav_title');?></h3>
+                <?php endif; ?>
                 <?php printNav($activeRoot, $activePage['page']->toArray()); ?>
             </div>
         </div>


### PR DESCRIPTION
This resolves #17. This gives users the option to change the side navigation's title from the default 'Contents' to whatever title they want. They can also remove the title entirely by deleting all text from the input.