### PR TITLE
Top nav

### DIFF
--- a/config/theme.ini
+++ b/config/theme.ini
@@ -29,7 +29,7 @@ elements.nav_items.type = "Number"
 elements.nav_items.options.label = "Top Navigation Max Items"
 elements.nav_items.options.info = "Maximum number of items to render in the top navigation. Set to 0 to disable top navigation."
 elements.nav_items.attributes.min = 0
-elements.nav_items.attributes.value = 4
+elements.nav_items.attributes.value = 5
 
 elements.logo.name = "banner"
 elements.logo.type = "Omeka\Form\Element\Asset"

--- a/config/theme.ini
+++ b/config/theme.ini
@@ -23,6 +23,14 @@ elements.nav_depth.options.info = "Maximum number of levels to show in the site'
 elements.nav_depth.attributes.min = 0
 elements.nav_depth.attributes.value = 0
 
+elements.nav_items.name = "nav_items"
+element.nav_items.attributes.id = "nav_items"
+elements.nav_items.type = "Number"
+elements.nav_items.options.label = "Top Navigation Max Items"
+elements.nav_items.options.info = "Maximum number of items to render in the top navigation. Set to 0 to disable top navigation."
+elements.nav_items.attributes.min = 0
+elements.nav_items.attributes.value = 4
+
 elements.logo.name = "banner"
 elements.logo.type = "Omeka\Form\Element\Asset"
 elements.logo.options.label = "Banner"

--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -49,7 +49,7 @@ $userBar = $this->userBar();
             .toc-card .card-title {
                 color: <?php echo $accentColor; ?>;
             }
-            ul.navigation li.parent:nth-child(n+<?php echo $this->themeSetting('nav_items'); ?>){
+            ul.navigation li.parent:nth-child(n+<?php echo $this->themeSetting('nav_items') + 1; ?>){
                 display:none;
             }
             <?php endif; ?>

--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -49,6 +49,9 @@ $userBar = $this->userBar();
             .toc-card .card-title {
                 color: <?php echo $accentColor; ?>;
             }
+            ul.navigation li.parent:nth-child(n+<?php echo $this->themeSetting('nav_items'); ?>){
+                display:none;
+            }
             <?php endif; ?>
         </style>
     </head>

--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -49,7 +49,7 @@ $userBar = $this->userBar();
             .toc-card .card-title {
                 color: <?php echo $accentColor; ?>;
             }
-            ul.navigation li.parent:nth-child(n+<?php echo $this->themeSetting('nav_items') + 1; ?>){
+            ul.navigation > li.parent:nth-child(n+<?php echo $this->themeSetting('nav_items') + 1; ?>){
                 display:none;
             }
             <?php endif; ?>

--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -49,7 +49,7 @@ $userBar = $this->userBar();
             .toc-card .card-title {
                 color: <?php echo $accentColor; ?>;
             }
-            ul.navigation > li.parent:nth-child(n+<?php echo $this->themeSetting('nav_items') + 1; ?>){
+            ul.navigation > li:nth-child(n+<?php echo $this->themeSetting('nav_items') + 1; ?>){
                 display:none;
             }
             <?php endif; ?>


### PR DESCRIPTION
This addresses #30 and #40 by adding a config that allows users to set the max number of items to place in the top navigation. Users would then control which items appear there by rearranging the order of the navigation tree.

Note: The native way to do this is by simply removing items from the navigation. However, KSharp uses the navigation tree to define individual exhibits. An alternative, and more radical, fix would be to use another method for define exhibits.