### PR TITLE
Convert setting value to int

### DIFF
--- a/view/layout/layout.phtml
+++ b/view/layout/layout.phtml
@@ -86,7 +86,7 @@ $userBar = $this->userBar();
         <nav>
             <?php
             echo $site->publicNav()->menu()->renderMenu(null, [
-                'maxDepth' => $this->themeSetting('nav_depth') - 1
+                'maxDepth' => intval($this->themeSetting('nav_depth')) - 1
             ]);
             ?>
         </nav>


### PR DESCRIPTION
This avoids type cohersion error in php 8.2 an fixes #58